### PR TITLE
chore: build configuration fixes

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -3,10 +3,6 @@ const ENV_VARS = {
   FORTMATIC_API_KEY: [process.env.FORTMATIC_API_KEY, ''],
   SENTRY_DSN: [process.env.SENTRY_DSN, ''],
   PORTIS_DAPP_ID: [process.env.PORTIS_DAPP_ID, ''],
-  SUBSCRIPTIONS_URL: [
-    process.env.SUBSCRIPTIONS_URL,
-    'https://court-backend.eth.aragon.network/subscriptions',
-  ],
   COMMIT_SHA: [process.env.COMMIT_SHA, ''],
   BUILD: [process.env.BUILD, ''],
   NODE_ENV: [process.env.NODE_ENV, 'development'],

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import * as Sentry from '@sentry/browser'
-import NextApp from 'next/app'
 import NextHead from 'next/head'
 import { useSpring, animated } from 'react-spring'
 import { createGlobalStyle } from 'styled-components'
@@ -12,7 +11,7 @@ if (env('SENTRY_DSN')) {
   Sentry.init({
     dsn: env('SENTRY_DSN'),
     environment: env('NODE_ENV'),
-    release: 'anj.aragon.org@' + env('BUILD'),
+    release: 'convert.aragon.org@' + env('BUILD'),
   })
 }
 


### PR DESCRIPTION
- Removes the `SUBSCRIPTIONS_URL`, which is unused
- Updates the sentry release name to be `convert.aragon.org` based