### PR TITLE
Links: Rename second link to help & link to court FAQ

### DIFF
--- a/components/ConversionForm/ConversionForm.js
+++ b/components/ConversionForm/ConversionForm.js
@@ -433,19 +433,15 @@ function Docs() {
       `}
     >
       <li>
-        <Anchor href="https://anj.aragon.org/">
-          About
+        <Anchor href="https://anj.aragon.org/">About</Anchor>
+      </li>
+      <li>
+        <Anchor href="https://help.aragon.org/article/48-aragon-court-faq">
+          Help
         </Anchor>
       </li>
       <li>
-        <Anchor href="https://help.aragon.org/article/41-aragon-court">
-          Docs
-        </Anchor>
-      </li>
-      <li>
-        <Anchor href="https://court.aragon.org/dashboard">
-          Court
-        </Anchor>
+        <Anchor href="https://court.aragon.org/dashboard">Court</Anchor>
       </li>
     </ul>
   )


### PR DESCRIPTION
As requested by design & @facuspagnuolo , we should now link to the [court FAQ](https://help.aragon.org/article/48-aragon-court-faq) on the converter & anj site.