### PR TITLE
Converter: reset allowance back to 0 before raising it

### DIFF
--- a/lib/web3-contracts.js
+++ b/lib/web3-contracts.js
@@ -208,9 +208,20 @@ export function useOpenOrder() {
         )
         if (allowance.lt(bigNum(amount))) {
           try {
+            // There's the case when an user has an allowance set to the market maker contract
+            // but wants to convert even more tokens this time. When dealing with this case,
+            // we want to reset the allowance back to zero, and then raise it.
+            if (!allowance.eq(0)) {
+              console.log('this ran')
+              const tx = await antContract.approve(marketMakerAddress, '0', {
+                gasLimit: 40000,
+              })
+              await tx.wait()
+            }
             await antContract.approve(marketMakerAddress, amount)
             // Don't wait for the approval to be mined before showing second transaction
           } catch (err) {
+            console.log(err)
             throw new Error('User did not approve transaction')
           }
         }

--- a/lib/web3-contracts.js
+++ b/lib/web3-contracts.js
@@ -212,16 +212,12 @@ export function useOpenOrder() {
             // but wants to convert even more tokens this time. When dealing with this case,
             // we want to reset the allowance back to zero, and then raise it.
             if (!allowance.eq(0)) {
-              console.log('this ran')
-              const tx = await antContract.approve(marketMakerAddress, '0', {
-                gasLimit: 40000,
-              })
+              const tx = await antContract.approve(marketMakerAddress, '0')
               await tx.wait()
             }
             await antContract.approve(marketMakerAddress, amount)
             // Don't wait for the approval to be mined before showing second transaction
           } catch (err) {
-            console.log(err)
             throw new Error('User did not approve transaction')
           }
         }


### PR DESCRIPTION
This fix handles the following case:

- The user has, as a result of previous transaction, set their allowance to a certain amount.
- After this, user tries to convert more ANT than what their allowance has permitted to spend.

In this case, it might be logical to think that one can just raise the allowance as required, but actually if we do so, the transaction will fail. What we need is to first reset it back to zero (waiting for this to actually be mined) and then raise it. This, sadly, adds another transaction to the flow in the case it happens.

We might also wanna discuss the copies of the stepper in the case this happens.